### PR TITLE
Only add adapters in neardal_mgr_adapters_parse()

### DIFF
--- a/lib/interface/org.neard.Manager.xml
+++ b/lib/interface/org.neard.Manager.xml
@@ -11,9 +11,11 @@
 		</method>
 		<method name="RegisterHandoverAgent">
 			<arg name="path" type="o" direction="in"/>
+			<arg name="type" type="s" direction="in"/>
 		</method>
 		<method name="UnregisterHandoverAgent">
 			<arg name="path" type="o" direction="in"/>
+			<arg name="type" type="s" direction="in"/>
 		</method>
 		<method name="RegisterNDEFAgent">
 			<arg name="path" type="o" direction="in"/>

--- a/lib/neardal.c
+++ b/lib/neardal.c
@@ -1081,7 +1081,9 @@ exit:
  * used to pass remote Out Of Band data.
  * If one of this callback is null, the agent is unregistered
  ****************************************************************************/
-errorCode_t neardal_agent_set_handover_cb(oob_push_agent_cb cb_oob_push_agent
+errorCode_t neardal_agent_set_handover_cb(
+						const gchar* carrier
+					  , oob_push_agent_cb cb_oob_push_agent
 					  , oob_req_agent_cb  cb_oob_req_agent
 				, oob_agent_free_cb cb_oob_release_agent
 					  , void *user_data)
@@ -1101,6 +1103,7 @@ errorCode_t neardal_agent_set_handover_cb(oob_push_agent_cb cb_oob_push_agent
 	agent.objPath			= g_strdup_printf("%s/handover/%d"
 							 , AGENT_PREFIX
 							 , agent.pid);
+	agent.carrierType	= g_strdup(carrier);
 	if (agent.objPath == NULL)
 		goto exit;
 
@@ -1109,17 +1112,20 @@ errorCode_t neardal_agent_set_handover_cb(oob_push_agent_cb cb_oob_push_agent
 		goto exit;
 
 	if (cb_oob_push_agent != NULL && cb_oob_req_agent != NULL)
-		/* RegisterNDEFAgent */
+		/* RegisterHandoverAgent */
 		org_neard_manager_call_register_handover_agent_sync(
 							       neardalMgr.proxy,
 							       agent.objPath,
+							       agent.carrierType,
 							       NULL,
 							   &neardalMgr.gerror);
 	else
-		/* UnregisterNDEFAgent */
+		/* UnregisterHandoverAgent */
 		org_neard_manager_call_unregister_handover_agent_sync(
 							neardalMgr.proxy,
-							agent.objPath, NULL,
+							agent.objPath,
+							agent.carrierType,
+							NULL,
 							 &neardalMgr.gerror);
 
 

--- a/lib/neardal.h
+++ b/lib/neardal.h
@@ -591,18 +591,22 @@ errorCode_t neardal_agent_set_NDEF_cb(char *tagType
 
 
 /*! \fn errorCode_t neardal_agent_set_handover_cb(
- * 					  oob_push_agent_cb cb_oob_push_agent
+ * 					  const gchar* carrier
+ * 					, oob_push_agent_cb cb_oob_push_agent
  * 					, oob_req_agent_cb  cb_oob_req_agent
 					, void *user_data)
  * @brief register or unregister two callbacks to handle handover connection.
  * If one of this callback is null, the agent is unregistered.
+ * @param carrier carrier type ("bluetooth" and "wifi" are valid choices)
  * @param cb_oob_push_agent used to pass remote Out Of Band data
  * @param cb_oob_req_agent used to get Out Of Band data
  * @param cb_oob_release_agent used to cleanup agent user data
  * @param user_data Client user data
  * @return errorCode_t error code
  **/
-errorCode_t neardal_agent_set_handover_cb(oob_push_agent_cb cb_oob_push_agent
+errorCode_t neardal_agent_set_handover_cb(
+						const gchar* carrier
+					  , oob_push_agent_cb cb_oob_push_agent
 					  , oob_req_agent_cb  cb_oob_req_agent
 				, oob_agent_free_cb cb_oob_release_agent
 					  , void *user_data);

--- a/lib/neardal_agent_mgr.h
+++ b/lib/neardal_agent_mgr.h
@@ -54,6 +54,7 @@ typedef struct {
 
 typedef struct {
 	gchar			*objPath;		/* agent object path */
+	gchar			*carrierType;	/* carrier type: "wifi" or "bluetooth" */
 	gint			pid;			/* process pid */
 
 	oob_req_agent_cb	cb_oob_req_agent;	/* client callback to

--- a/lib/neardal_manager.c
+++ b/lib/neardal_manager.c
@@ -295,18 +295,24 @@ static void neardal_mgr_prv_cb_adapter_removed(OrgNeardManager *proxy,
 static void neardal_mgr_adapters_parse(GVariant *v, char ***adps, gsize *nadps)
 {
 	char *s = NULL;
-	GVariantIter iter;
+	char *t = NULL;
+	GVariantIter iter, *iter2;
 
 	*adps = g_new0(char *, g_variant_n_children(v) + 1);
 	*nadps = 0;
 
 	g_variant_iter_init(&iter, v);
 
-	while (g_variant_iter_loop(&iter, "{o*}", &s, NULL)) {
-		if (g_str_has_prefix(s, "/org/neard/nfc")) {
-			NEARDAL_TRACEF("Found adapter: %s\n", s);
-			(*adps)[(*nadps)++] = s;
-			s = NULL;
+	while (g_variant_iter_loop(&iter, "{oa{sa{sv}}}", &s, &iter2, NULL)) {
+		while (g_variant_iter_loop(iter2, "{s*}", &t, NULL)) {
+			if(!strcmp(t, "org.neard.Adapter"))
+			{
+				NEARDAL_TRACEF("Found adapter: %s\n", s);
+				(*adps)[(*nadps)++] = s;
+				s = NULL;
+				g_free(t);
+				break;
+			}
 		}
 	}
 

--- a/lib/neardal_tools.c
+++ b/lib/neardal_tools.c
@@ -185,7 +185,7 @@ GHashTable *neardal_tools_prv_create_dict(void)
  * neardal_tools_prv_add_dict_entry: add an entry in a dictionnary
  ****************************************************************************/
 errorCode_t neardal_tools_prv_add_dict_entry(GVariantBuilder *builder
-					     , gchar *key, void *value
+					     , const gchar *key, void *value
 					     , gsize valueSize
 					     , int gVariantType)
 {

--- a/lib/neardal_tools.h
+++ b/lib/neardal_tools.h
@@ -67,7 +67,7 @@ GHashTable *neardal_tools_prv_create_dict(void);
  * neardal_tools_prv_add_dict_entry: add an entry in a dictionnary
  *****************************************************************************/
 errorCode_t neardal_tools_prv_add_dict_entry(GVariantBuilder *builder
-					     , gchar *key, void *value
+					     , const gchar *key, void *value
 					     , gsize valueSize
 					     , int gVariantType);
 

--- a/ncl/ncl_cmd.c
+++ b/ncl/ncl_cmd.c
@@ -1289,7 +1289,7 @@ exit:
  * ncl_cmd_(un)register_handover_agent : BEGIN
  * Handle a record macthing a registered tag type
  ****************************************************************************/
-void ncl_cmd_handover_req_agent_cb(unsigned char *blobEIR
+void ncl_cmd_handover_req_bluetooth_agent_cb(unsigned char *blobEIR
 				   , unsigned int blobSize
 				   , unsigned char ** oobData
 				   , unsigned int * oobDataSize
@@ -1316,7 +1316,7 @@ void ncl_cmd_handover_req_agent_cb(unsigned char *blobEIR
 	NCL_CMD_DUMP(*oobData, *oobDataSize);
 }
 
-void ncl_cmd_handover_push_agent_cb (unsigned char *blobEIR
+void ncl_cmd_handover_push_bluetooth_agent_cb (unsigned char *blobEIR
 				     , unsigned int blobSize
 				     , void *user_data)
 {
@@ -1326,6 +1326,46 @@ void ncl_cmd_handover_push_agent_cb (unsigned char *blobEIR
 
 	NCL_CMD_PRINTF("\n");
 }
+
+void ncl_cmd_handover_req_wifi_agent_cb(unsigned char *blobWSC
+				   , unsigned int blobSize
+				   , unsigned char ** oobData
+				   , unsigned int * oobDataSize
+				   , freeFunc *freeF
+				   , void *user_data)
+{
+	const unsigned char test_data[] = {0x10,0x4A,0x00,0x01,0x10,
+			 	 	 	0x10,0x45,0x00,0x08,
+			 	 	 	0x74,0x65,0x73,0x74,0x73,0x73,0x69,0x64,
+			 	 	 	0x10,0x27,0x00,0x06,
+			 	 	 	0x62,0x6C,0x61,0x62,0x6C,0x61};
+
+	(void) user_data;
+
+	NCL_CMD_PRINTF("Received blobWSC = \n");
+	NCL_CMD_DUMP(blobWSC, blobSize);
+
+	NCL_CMD_PRINTF("user_data= %s\n", (char *) user_data);
+
+	*oobData = g_try_malloc0(sizeof(test_data));
+	memcpy(*oobData , test_data, sizeof(test_data));
+	*oobDataSize = sizeof(test_data);
+	*freeF = g_free;
+	NCL_CMD_PRINTF("return oobData = \n");
+	NCL_CMD_DUMP(*oobData, *oobDataSize);
+}
+
+void ncl_cmd_handover_push_wifi_agent_cb (unsigned char *blobWSC
+				     , unsigned int blobSize
+				     , void *user_data)
+{
+	NCL_CMD_PRINTF("Received blobWSC = \n");
+	NCL_CMD_DUMP(blobWSC, blobSize);
+	(void) user_data;
+
+	NCL_CMD_PRINTF("\n");
+}
+
 
 void ncl_cmd_handover_release_agent_cb(void *user_data)
 {
@@ -1337,52 +1377,152 @@ void ncl_cmd_handover_release_agent_cb(void *user_data)
 static NCLError ncl_cmd_register_handover_agent(int argc, char *argv[])
 {
 	errorCode_t	ec		= NEARDAL_SUCCESS;
-	char		*test_user_data;
+	NCLError	nclErr;
+	static char		*carrier = NULL;
+	char		*test_user_data = NULL;
 
-	(void) argc;
-	(void) argv;
+	static GOptionEntry options[] = {
+		{ "carrier", 's', 0, G_OPTION_ARG_STRING , &carrier
+				, "carrier to register",
+				"'bluetooth, wifi'" },
+
+		{ NULL, 0, 0, 0, NULL, NULL, NULL} /* End of List */
+	};
+
+	if (argc > 1) {
+		/* Parse options */
+		carrier = NULL;
+		nclErr = ncl_cmd_prv_parseOptions(&argc, &argv, options);
+	} else
+		nclErr = NCLERR_PARSING_PARAMETERS;
+
+	if (nclErr != NCLERR_NOERROR)
+		goto exit;
 
 	/* Install Neardal Callback*/
 	if (sNclCmdCtx.cb_initialized == false)
 		ncl_cmd_install_callback();
 
-	test_user_data = g_strdup("test HANDOVER user data");
+	if (!strcmp(carrier, "bluetooth")) {
+		test_user_data = g_strdup("test HANDOVER user data");
 
-	ec = neardal_agent_set_handover_cb(ncl_cmd_handover_push_agent_cb
-					   , ncl_cmd_handover_req_agent_cb
-					   , ncl_cmd_handover_release_agent_cb
-					   , test_user_data);
+		ec = neardal_agent_set_handover_cb(
+							 carrier
+						   , ncl_cmd_handover_push_bluetooth_agent_cb
+						   , ncl_cmd_handover_req_bluetooth_agent_cb
+						   , ncl_cmd_handover_release_agent_cb
+						   , test_user_data);
+	} else if (!strcmp(carrier, "wifi")) {
+		test_user_data = g_strdup("test HANDOVER user data");
+
+		ec = neardal_agent_set_handover_cb(
+							 carrier
+						   , ncl_cmd_handover_push_wifi_agent_cb
+						   , ncl_cmd_handover_req_wifi_agent_cb
+						   , ncl_cmd_handover_release_agent_cb
+						   , test_user_data);
+	}
+	else
+		nclErr = NCLERR_PARSING_PARAMETERS;
+
 	if (ec != NEARDAL_SUCCESS) {
 		NCL_CMD_PRINTF("Set handover callback failed! error:%d='%s'.\n",
 			       ec, neardal_error_get_text(ec));
-		return NCLERR_LIB_ERROR;
+		nclErr = NCLERR_LIB_ERROR;
 	}
 	NCL_CMD_PRINT("\nExit with error code %d:%s\n", ec,
 		      neardal_error_get_text(ec));
 
-	return NCLERR_NOERROR;
+exit:
+	if (carrier != NULL)
+		g_free(carrier);
+
+	if (test_user_data != NULL)
+		g_free(test_user_data);
+
+	if (nclErr != NCLERR_NOERROR) {
+		NCL_CMD_PRINT("Sample (WiFi agent):");
+		NCL_CMD_PRINT("e.g. < %s --carrier wifi >\n"
+				 , argv[0]);
+	}
+
+	if (ec != NEARDAL_SUCCESS)
+		nclErr = NCLERR_LIB_ERROR;
+
+	return nclErr;
 }
 static NCLError ncl_cmd_unregister_handover_agent(int argc, char *argv[])
 {
 	errorCode_t	ec		= NEARDAL_SUCCESS;
+	NCLError	nclErr;
+	static char		*carrier = NULL;
+	char		*test_user_data = NULL;
 
-	(void) argc;
-	(void) argv;
+	static GOptionEntry options[] = {
+		{ "carrier", 's', 0, G_OPTION_ARG_STRING , &carrier
+				, "carrier to unregister",
+				"'bluetooth, wifi'" },
+
+		{ NULL, 0, 0, 0, NULL, NULL, NULL} /* End of List */
+	};
+
+	if (argc > 1) {
+		/* Parse options */
+		carrier = NULL;
+		nclErr = ncl_cmd_prv_parseOptions(&argc, &argv, options);
+	} else
+		nclErr = NCLERR_PARSING_PARAMETERS;
+
+	if (nclErr != NCLERR_NOERROR)
+		goto exit;
 
 	/* Install Neardal Callback*/
 	if (sNclCmdCtx.cb_initialized == false)
 		ncl_cmd_install_callback();
 
-	ec = neardal_agent_set_handover_cb(NULL, NULL, NULL, NULL);
+	if (!strcmp(carrier, "bluetooth")) {
+		ec = neardal_agent_set_handover_cb(
+							 carrier
+						   , NULL
+						   , NULL
+						   , NULL
+						   , NULL);
+	} else if (!strcmp(carrier, "wifi")) {
+		ec = neardal_agent_set_handover_cb(
+							 carrier
+						   , NULL
+						   , NULL
+						   , NULL
+						   , NULL);
+	}
+	else
+		nclErr = NCLERR_PARSING_PARAMETERS;
+
 	if (ec != NEARDAL_SUCCESS) {
 		NCL_CMD_PRINTF("Set handover callback failed! error:%d='%s'.\n",
 			       ec, neardal_error_get_text(ec));
-		return NCLERR_LIB_ERROR;
+		nclErr = NCLERR_LIB_ERROR;
 	}
 	NCL_CMD_PRINT("\nExit with error code %d:%s\n", ec,
 		      neardal_error_get_text(ec));
 
-	return NCLERR_NOERROR;
+exit:
+	if (carrier != NULL)
+		g_free(carrier);
+
+	if (test_user_data != NULL)
+		g_free(test_user_data);
+
+	if (nclErr != NCLERR_NOERROR) {
+		NCL_CMD_PRINT("Sample (WiFi agent):");
+		NCL_CMD_PRINT("e.g. < %s --carrier wifi >\n"
+				 , argv[0]);
+	}
+
+	if (ec != NEARDAL_SUCCESS)
+		nclErr = NCLERR_LIB_ERROR;
+
+	return nclErr;
 }
 /*****************************************************************************
  * ncl_cmd_(un)register_handover_agent : END


### PR DESCRIPTION
This change checks whether a DBUS object exposes the Adapter interface in neardal_mgr_adapters_parse() to avoid adding other objects (tags, devices, etc) to the adapters' list.