### PR TITLE
Adding protocol-specific information parsing for NFC tags type A & F

### DIFF
--- a/demo/demo.c
+++ b/demo/demo.c
@@ -39,6 +39,20 @@ static void cb_adapter_prop_changed(char *adpName, char *propName,
 	printf("\n");
 }
 
+/*****************************************************************************
+ * Get readable string of bytes
+ ****************************************************************************/
+static gchar* bytes_to_str(GBytes* bytes)
+{
+	gchar* str = g_malloc0( 2*g_bytes_get_size(bytes) + 1 );
+	const guint8* data = g_bytes_get_data(bytes, NULL);
+	for(int i = 0 ; i < g_bytes_get_size(bytes); i++)
+	{
+		sprintf(&str[2*i], "%02X", data[i]);
+	}
+	return str;
+}
+
 static void dump_tag(neardal_tag *tag)
 {
 	char **records;
@@ -76,6 +90,48 @@ static void dump_tag(neardal_tag *tag)
 	}
 	printf("\n");
 	printf("---- ReadOnly:\t\t%s\n", tag->readOnly ? "TRUE" : "FALSE");
+	if(tag->iso14443aAtqa != NULL)
+	{
+		gchar *str = bytes_to_str(tag->iso14443aAtqa);
+		printf("---- ISO14443A ATQA:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->iso14443aSak != NULL)
+	{
+		gchar *str = bytes_to_str(tag->iso14443aSak);
+		printf("---- ISO14443A SAK:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->iso14443aUid != NULL)
+	{
+		gchar *str = bytes_to_str(tag->iso14443aUid);
+		printf("---- ISO14443A UID:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaManufacturer != NULL)
+	{
+		gchar *str = bytes_to_str(tag->felicaManufacturer);
+		printf("---- Felica Manufacturer:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaCid != NULL)
+	{
+		gchar *str = bytes_to_str(tag->felicaCid);
+		printf("---- Felica CID:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaIc != NULL)
+	{
+		gchar *str = bytes_to_str(tag->felicaIc);
+		printf("---- Felica IC Code:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaMaxRespTimes != NULL)
+	{
+		gchar *str = bytes_to_str(tag->felicaMaxRespTimes);
+		printf("---- Felica Maximum Response times:\t\t'%s'\n", str);
+		g_free(str);
+	}
 }
 
 static void dump_record(neardal_record *record)

--- a/lib/interface/org.neard.Tag.xml
+++ b/lib/interface/org.neard.Tag.xml
@@ -8,5 +8,26 @@
 		<method name="GetRawNDEF">
 			<arg name="NDEF" type="ay" direction="out"/>
 		</method>
+		<property name="Iso14443aUid" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
+		<property name="Iso14443aAtqa" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
+		<property name="Iso14443aSak" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
+		<property name="FelicaManufacturer" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
+		<property name="FelicaCid" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
+		<property name="FelicaIc" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
+		<property name="FelicaMaxRespTimes" type="ay" access="read">
+			<annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+		</property>
 	</interface>
 </node>

--- a/lib/neardal.c
+++ b/lib/neardal.c
@@ -705,6 +705,15 @@ void neardal_free_tag(neardal_tag *tag)
 		g_free(tag->tagType[ct++]);
 	g_free(tag->tagType);
 
+	/* Freeing ISO14443A & Felica-specific properties */
+    g_clear_pointer(&tag->iso14443aAtqa, g_bytes_unref);
+    g_clear_pointer(&tag->iso14443aSak, g_bytes_unref);
+    g_clear_pointer(&tag->iso14443aUid, g_bytes_unref);
+    g_clear_pointer(&tag->felicaManufacturer, g_bytes_unref);
+    g_clear_pointer(&tag->felicaCid, g_bytes_unref);
+    g_clear_pointer(&tag->felicaIc, g_bytes_unref);
+    g_clear_pointer(&tag->felicaMaxRespTimes, g_bytes_unref);
+
 	/* Freeing adapter struct */
 	g_free(tag);
 }
@@ -765,6 +774,22 @@ errorCode_t neardal_get_tag_properties(const char *tagName,
 		err = NEARDAL_SUCCESS;
 	}
 
+	/* ISO14443A-specific, Felica-Specific properties */
+	if(tagProp->iso14443aAtqa != NULL)
+		tagClient->iso14443aAtqa		= g_bytes_ref(tagProp->iso14443aAtqa);
+	if(tagProp->iso14443aSak != NULL)
+		tagClient->iso14443aSak		= g_bytes_ref(tagProp->iso14443aSak);
+	if(tagProp->iso14443aUid != NULL)
+		tagClient->iso14443aUid		= g_bytes_ref(tagProp->iso14443aUid);
+	if(tagProp->felicaManufacturer != NULL)
+		tagClient->felicaManufacturer		= g_bytes_ref(tagProp->felicaManufacturer);
+	if(tagProp->felicaCid != NULL)
+		tagClient->felicaCid		= g_bytes_ref(tagProp->felicaCid);
+	if(tagProp->felicaIc != NULL)
+		tagClient->felicaIc		= g_bytes_ref(tagProp->felicaIc);
+	if(tagProp->felicaMaxRespTimes != NULL)
+		tagClient->felicaMaxRespTimes		= g_bytes_ref(tagProp->felicaMaxRespTimes);
+
 	tagClient->nbTagTypes = 0;
 	tagClient->tagType = NULL;
 	/* Count TagTypes */
@@ -784,6 +809,7 @@ errorCode_t neardal_get_tag_properties(const char *tagName,
 		tagClient->tagType[ct] = g_strdup(tagProp->tagType[ct]);
 		ct++;
 	}
+
 	err = NEARDAL_SUCCESS;
 
 exit:

--- a/lib/neardal.h
+++ b/lib/neardal.h
@@ -31,6 +31,9 @@
 #define NEARDAL_H
 #include "neardal_errors.h"
 
+#include <glib.h>
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif	/* __cplusplus */
@@ -88,6 +91,20 @@ typedef struct {
 	const char	*type;
 /*! @brief Read-Only flag (is tag writable?) */
 	short		readOnly;
+/*! @brief ISO14443A ATQA (if present) */
+	GBytes		*iso14443aAtqa;
+/*! @brief ISO14443A SAK (if present) */
+	GBytes		*iso14443aSak;
+/*! @brief ISO14443A UID (if present) */
+	GBytes		*iso14443aUid;
+/*! @brief Felica Manufacturer info (if present) */
+	GBytes		*felicaManufacturer;
+/*! @brief Felica CID (if present) */
+	GBytes		*felicaCid;
+/*! @brief Felica IC Code (if present) */
+	GBytes		*felicaIc;
+/*! @brief Felica Max reponse times (if present) */
+	GBytes		*felicaMaxRespTimes;
 } neardal_tag;
 
 /*!

--- a/lib/neardal_tag.c
+++ b/lib/neardal_tag.c
@@ -104,6 +104,43 @@ static errorCode_t neardal_tag_prv_read_properties(TagProp *tagProp)
 	if (tmpOut != NULL)
 		tagProp->readOnly = g_variant_get_boolean(tmpOut);
 
+	/* ISO14443A-specific fields (optional) */
+	tmpOut = g_variant_lookup_value(tmp, "Iso14443aAtqa",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->iso14443aAtqa = g_variant_get_data_as_bytes(tmpOut);
+
+	tmpOut = g_variant_lookup_value(tmp, "Iso14443aSak",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->iso14443aSak = g_variant_get_data_as_bytes(tmpOut);
+
+	tmpOut = g_variant_lookup_value(tmp, "Iso14443aUid",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->iso14443aUid = g_variant_get_data_as_bytes(tmpOut);
+
+	/* Felica-specific fields (optional) */
+	tmpOut = g_variant_lookup_value(tmp, "FelicaManufacturer",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->felicaManufacturer = g_variant_get_data_as_bytes(tmpOut);
+
+	tmpOut = g_variant_lookup_value(tmp, "FelicaCid",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->felicaCid = g_variant_get_data_as_bytes(tmpOut);
+
+	tmpOut = g_variant_lookup_value(tmp, "FelicaIc",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->felicaIc = g_variant_get_data_as_bytes(tmpOut);
+
+	tmpOut = g_variant_lookup_value(tmp, "FelicaMaxRespTimes",
+			G_VARIANT_TYPE_BYTESTRING);
+	if ( (tmpOut != NULL) && (g_variant_n_children(tmpOut) > 0) )
+		tagProp->felicaMaxRespTimes = g_variant_get_data_as_bytes(tmpOut);
+
 exit:
 	return err;
 }
@@ -167,6 +204,13 @@ static void neardal_tag_prv_free(TagProp **tagProp)
 	g_free((*tagProp)->name);
 	g_free((*tagProp)->type);
 	g_strfreev((*tagProp)->tagType);
+    g_clear_pointer(&((*tagProp)->iso14443aAtqa), g_bytes_unref);
+    g_clear_pointer(&((*tagProp)->iso14443aSak), g_bytes_unref);
+    g_clear_pointer(&((*tagProp)->iso14443aUid), g_bytes_unref);
+    g_clear_pointer(&((*tagProp)->felicaManufacturer), g_bytes_unref);
+    g_clear_pointer(&((*tagProp)->felicaCid), g_bytes_unref);
+    g_clear_pointer(&((*tagProp)->felicaIc), g_bytes_unref);
+    g_clear_pointer(&((*tagProp)->felicaMaxRespTimes), g_bytes_unref);
 	g_free((*tagProp));
 	(*tagProp) = NULL;
 }

--- a/lib/neardal_tag.h
+++ b/lib/neardal_tag.h
@@ -41,6 +41,15 @@ typedef struct {
 	gchar		**tagType;	/* array of tag types */
 	gsize		tagTypeLen;
 	gboolean	readOnly;	/* Read-Only flag */
+
+	GBytes		*iso14443aAtqa;	/* ISO14443A ATQA */
+	GBytes		*iso14443aSak;	/* ISO14443A SAK */
+	GBytes		*iso14443aUid;	/* ISO14443A UID */
+
+	GBytes		*felicaManufacturer;	/* Felica Manufacturer info */
+	GBytes		*felicaCid;	/* Felica CID */
+	GBytes		*felicaIc;	/* Felica IC code */
+	GBytes		*felicaMaxRespTimes;	/* Felica Max response times */
 } TagProp;
 
 /*****************************************************************************

--- a/ncl/ncl_cmd.c
+++ b/ncl/ncl_cmd.c
@@ -49,6 +49,20 @@ NCLError ncl_cmd_list(int argc, char *argv[]);
 
 /* Local Utilities functions */
 /*****************************************************************************
+ * Get readable string of bytes
+ ****************************************************************************/
+static gchar* ncl_cmd_prv_bytes_to_str(GBytes* bytes)
+{
+	gchar* str = g_malloc0( 2*g_bytes_get_size(bytes) + 1 );
+	const guint8* data = g_bytes_get_data(bytes, NULL);
+	for(int i = 0 ; i < g_bytes_get_size(bytes); i++)
+	{
+		sprintf(&str[2*i], "%02X", data[i]);
+	}
+	return str;
+}
+
+/*****************************************************************************
  * Tool function : help command to dump parameters command
  ****************************************************************************/
 static void ncl_cmd_prv_dumpOptions(GOptionEntry *options)
@@ -212,6 +226,49 @@ static void ncl_cmd_prv_dump_tag(neardal_tag *tag)
 	NCL_CMD_PRINT("\n");
 	NCL_CMD_PRINT(".. ReadOnly:\t\t%s\n"	,
 		      tag->readOnly ? "TRUE" : "FALSE");
+
+	if(tag->iso14443aAtqa != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->iso14443aAtqa);
+		NCL_CMD_PRINT(".. ISO14443A ATQA:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->iso14443aSak != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->iso14443aSak);
+		NCL_CMD_PRINT(".. ISO14443A SAK:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->iso14443aUid != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->iso14443aUid);
+		NCL_CMD_PRINT(".. ISO14443A UID:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaManufacturer != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->felicaManufacturer);
+		NCL_CMD_PRINT(".. Felica Manufacturer:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaCid != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->felicaCid);
+		NCL_CMD_PRINT(".. Felica CID:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaIc != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->felicaIc);
+		NCL_CMD_PRINT(".. Felica IC Code:\t\t'%s'\n", str);
+		g_free(str);
+	}
+	if(tag->felicaMaxRespTimes != NULL)
+	{
+		gchar *str = ncl_cmd_prv_bytes_to_str(tag->felicaMaxRespTimes);
+		NCL_CMD_PRINT(".. Felica Maximum Response times:\t\t'%s'\n", str);
+		g_free(str);
+	}
 }
 
 /*****************************************************************************


### PR DESCRIPTION
This changes to NeardAL would add parsing support for the following tag parameters if exposed by the Neard D-Bus API:
* ISO14443A
  * ATQA
  * UID
  * SAK
* Felica
  * Manufacturer info
  * CID
  * IC Code
  * Maximum response times
   