### PR TITLE
fix static linking with libedit or readline

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,10 +68,16 @@ PKG_CHECK_MODULES(gio, gio-unix-2.0 >= 2.30,
 	AC_SUBST([gio_LIBS]),
 	AC_MSG_ERROR(gio-unix-2.0 >= 2.30 is required))
 
-AC_SEARCH_LIBS([rl_initialize], [edit readline],
-	[AS_IF([echo $LIBS | grep -q "-ledit"],
-		[CPPFLAGS="-DHAVE_LIBEDIT $CPPFLAGS"])],
-	[AC_MSG_ERROR(editline or readline is required)])
+PKG_CHECK_MODULES(libedit, libedit,
+	[CPPFLAGS="-DHAVE_LIBEDIT $libedit_CFLAGS $CPPFLAGS"
+	 LIBS="$libedit_LIBS $LIBS"],
+	[PKG_CHECK_MODULES(readline, readline,
+		[CPPFLAGS="$readline_CFLAGS $CPPFLAGS"
+		 LIBS="$readline_LIBS $LIBS"],
+		AC_SEARCH_LIBS([rl_initialize], [edit readline],
+			[AS_IF([echo $LIBS | grep -q "-ledit"],
+				[CPPFLAGS="-DHAVE_LIBEDIT $CPPFLAGS"])],
+			[AC_MSG_ERROR(editline or readline is required)]))])
 
 AC_PATH_TOOL([DOXYGEN], [doxygen])
 AM_CONDITIONAL([HAVE_DOXYGEN], [test ! -z "$DOXYGEN"])


### PR DESCRIPTION
Use PKG_CHECK_MODULES to find libedit or readline and continue to use
AC_SEARCH_LIBS as a fallback

By using PKG_CHECK_MODULES, static link will work as -lncurses or -lbsd
will be automatically added

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>