### PR TITLE
lib: fix memory corruption

### DIFF
--- a/lib/neardal_record.c
+++ b/lib/neardal_record.c
@@ -31,7 +31,6 @@ void neardal_record_free(neardal_record *r)
 {
 	g_return_if_fail(r);
 	neardal_g_strfreev((void **) r, &r->uriObjSize);
-	memset(r, 0, sizeof(*r));
 }
 
 void neardal_free_record(neardal_record *record) \

--- a/lib/neardal_tools.c
+++ b/lib/neardal_tools.c
@@ -32,9 +32,12 @@
 void neardal_g_strfreev(void **array, void *end)
 {
 	void **p = array;
-	for (; (void *) p < end; p++)
+	for (; (void *) p < end; p++) {
 		g_free(*p);
+		*p = NULL;
+	}
 	g_free(array);
+	array = NULL;
 }
 
 void neardal_g_variant_add_parsed(GVariant **v, const char *format, ...)


### PR DESCRIPTION
 The current commit fixes an invalid memory  access
 which manifests as a random segfault  when executing
 continuous tag read operations.

 The corruption happens when releasing the  memory allocated to a
 record: in the time between  the memory being g_free'd and the
 subsequent memset  operation, the memory could have been reused by
 some  other process. And since memory allocation  depends on
 system-wide factors, it makes this bug hard to track.

 Tested using ACR122U reader and NTAG213
 tags on Automotive Grade Linux (flounder,
 guppy and master branches)

Signed-off-by: Raquel Medina <raquel.medina@konsulko.com>