### PR TITLE
configure.ac: fix autoreconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_SRCDIR([lib/neardal.c])
 AC_CONFIG_HEADERS([config.h])
 
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
Add foreign to AM_INIT_AUTOMAKE otherwise automake without --add-missing
fails on:
Makefile.am: error: required file './ChangeLog' not found

It should be noted that foreign was correctly specified before
6563ef67a909ea0cd26fe73803786914ad708ef3. This commit removed foreign
without giving any rationale except "fix automake".

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>