### PR TITLE
lib/neardal.h: fix build with gcc 10

### DIFF
--- a/lib/neardal.h
+++ b/lib/neardal.h
@@ -638,7 +638,7 @@ neardal_record *neardal_g_variant_to_record(GVariant *in);
 
 void neardal_trace(const char *func, FILE *fp, char *fmt, ...)
 	__attribute__((format(printf, 3, 4)));
-int (*neardal_output_cb)(FILE *fp, const char *fmt, va_list ap);
+extern int (*neardal_output_cb)(FILE *fp, const char *fmt, va_list ap);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Define neardal_output_cb as extern to avoid the following build failure
with gcc 10 (which defaults to -fno-common):

```
/srv/storage/autobuild/run/instance-2/output-1/host/lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: ./.libs/neardal_adapter.o:(.bss+0x0): multiple definition of `neardal_output_cb'; ./.libs/neardal.o:(.bss+0x68): first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/7efb100c899b67ffd570f73c202442f95ca5397e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>